### PR TITLE
Provide strict prototypes in function definitions

### DIFF
--- a/src/color.c
+++ b/src/color.c
@@ -28,12 +28,12 @@ static int enabled = 0;
 #define COLOR_CYAN     "\033[36;1m"
 #define EMPTY_STR      ""
 
-void color_enable()
+void color_enable(void)
 {
 	enabled = 1;
 }
 
-const char *color_reset()
+const char *color_reset(void)
 {
 	if (!enabled) {
 		return EMPTY_STR;
@@ -42,7 +42,7 @@ const char *color_reset()
 	return COLOR_RESET;
 }
 
-const char *color_error()
+const char *color_error(void)
 {
 	if (!enabled) {
 		return EMPTY_STR;
@@ -51,7 +51,7 @@ const char *color_error()
 	return COLOR_RED;
 }
 
-const char *color_warning()
+const char *color_warning(void)
 {
 	if (!enabled) {
 		return EMPTY_STR;
@@ -60,7 +60,7 @@ const char *color_warning()
 	return COLOR_YELLOW;
 }
 
-const char *color_note()
+const char *color_note(void)
 {
 	if (!enabled) {
 		return EMPTY_STR;
@@ -69,7 +69,7 @@ const char *color_note()
 	return COLOR_MAGENTA;
 }
 
-const char *color_ok()
+const char *color_ok(void)
 {
 	if (!enabled) {
 		return EMPTY_STR;

--- a/src/maps.c
+++ b/src/maps.c
@@ -571,7 +571,7 @@ void visit_all_in_permmacros_map(void (*visitor)(const char *name, const struct 
 	}
 }
 
-unsigned int permmacros_map_count()
+unsigned int permmacros_map_count(void)
 {
 	return HASH_CNT(hh_permmacros, permmacros_map);
 }
@@ -590,7 +590,7 @@ unsigned int permmacros_map_count()
 		free(cur_if); \
 } \
 
-void free_all_maps()
+void free_all_maps(void)
 {
 
 	struct hash_elem *cur_decl, *tmp_decl;

--- a/src/parse_functions.c
+++ b/src/parse_functions.c
@@ -64,7 +64,7 @@ void set_current_module_name(const char *mn)
 	module_name = xstrdup(mn);
 }
 
-char *get_current_module_name()
+char *get_current_module_name(void)
 {
 	return module_name;
 }
@@ -842,7 +842,7 @@ enum selint_error insert_role_attribute(struct policy_node **cur, const char *ro
 	return insert_attribute(cur, ATTR_ROLE, role, attrs, lineno);
 }
 
-void cleanup_parsing()
+void cleanup_parsing(void)
 {
 	if (module_name) {
 		free(module_name);

--- a/src/perm_macro.c
+++ b/src/perm_macro.c
@@ -517,7 +517,7 @@ static void free_perm_macro(struct perm_macro *to_free)
 	}
 }
 
-void free_permmacros()
+void free_permmacros(void)
 {
 	initialized = false;
 

--- a/src/startup.c
+++ b/src/startup.c
@@ -94,7 +94,7 @@ enum selint_error load_access_vectors_source(const char *av_path)
 	return SELINT_SUCCESS;
 }
 
-void load_modules_normal()
+void load_modules_normal(void)
 {
 
 }

--- a/src/te_checks.c
+++ b/src/te_checks.c
@@ -846,7 +846,7 @@ struct check_result *check_declaration_interface_nameclash(__attribute__((unused
 	return NULL;
 }
 
-bool check_unknown_permission_condition()
+bool check_unknown_permission_condition(void)
 {
 	// ignore if no permission or permission macro have been parsed
 	if (permmacros_map_count() == 0) {
@@ -898,7 +898,7 @@ struct check_result *check_unknown_permission(__attribute__((unused)) const stru
 	return NULL;
 }
 
-bool check_unknown_class_condition()
+bool check_unknown_class_condition(void)
 {
 	// ignore if no class has been parsed
 	if (decl_map_count(DECL_CLASS) == 0) {

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -20,7 +20,7 @@
 
 #include "test_utils.h"
 
-struct av_rule_data * make_example_av_rule() {
+struct av_rule_data * make_example_av_rule(void) {
 
 	// allow foo_t { bar_t baz_t }:file { read write getattr };
 	struct av_rule_data *av_rule_data = malloc(sizeof(struct av_rule_data));


### PR DESCRIPTION
Clang 15 starts to complain about non-strict prototypes in function
definitions:

    parse_functions.c:67:30: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    char *get_current_module_name()
                                 ^
                                  void