### PR TITLE
Be more permissive in parsing of defines.

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -687,8 +687,6 @@ arbitrary_m4_string:
 	m4_string_elem
 	|
 	m4_string_elem arbitrary_m4_string
-	|
-	BACKTICK m4_string_elem SINGLE_QUOTE
 	;
 
 m4_string_elem:
@@ -711,6 +709,18 @@ m4_string_elem:
 	SEMICOLON
 	|
 	DASH
+	|
+	av_type
+	|
+	OPTIONAL_POLICY
+	|
+	IFDEF
+	|
+	GEN_REQUIRE
+	|
+	COMMENT
+	|
+	BACKTICK arbitrary_m4_string SINGLE_QUOTE
 	;
 
 condition:
@@ -924,6 +934,8 @@ define_expansion:
 	BACKTICK arbitrary_m4_string SINGLE_QUOTE
 	|
 	STRING { free($1); }
+	|
+	BACKTICK SINGLE_QUOTE
 	;
 
 maybe_string_comma:

--- a/tests/sample_policy_files/uncommon.te
+++ b/tests/sample_policy_files/uncommon.te
@@ -144,3 +144,14 @@ anoninodetrans_pattern(foo_t, bar_t, "[io_uring]")
 gen_require(`
 	all_userspace_class_perms
 ')
+
+define(`my_var',`')
+
+define(`my_other_var',`
+# This is a comment
+allow foo_t self:capability sys_ptrace;
+
+optional_policy(`
+	call_some_interface(foo_t)
+')
+')


### PR DESCRIPTION
Support scenarios like:

define(`foo', `')

and

define(`bar',`
\#This is a comment
')