### PR TITLE
Add new check to warn about incorrect usage of audit_access permission

### DIFF
--- a/README
+++ b/README
@@ -187,6 +187,7 @@ CHECK IDS
 	W-010: Call to unknown interface
 	W-011: Declaration in require block not defined in own module
 	W-012: Conditional expression contains unknown identifier
+	W-013: Incorrect usage of audit_access permission
 
 	E-002: Bad file context format
 	E-003: Nonexistent user listed in fc file

--- a/check_examples.txt
+++ b/check_examples.txt
@@ -148,6 +148,13 @@ W-011:
 		')
 	')
 
+W-012:
+
+	# in module foo
+	if (bar_cond) {
+		...
+	}
+
 Error:
 
 E-002:

--- a/check_examples.txt
+++ b/check_examples.txt
@@ -155,6 +155,10 @@ W-012:
 		...
 	}
 
+W-013:
+
+	allow foo_t bar_t:file audit_access;
+
 Error:
 
 E-002:

--- a/src/check_hooks.h
+++ b/src/check_hooks.h
@@ -64,6 +64,7 @@ enum warn_ids {
 	W_ID_UNKNOWN_CALL      = 10,
 	W_ID_IF_DECL_NOT_OWN   = 11,
 	W_ID_UNKNOWN_COND_ID   = 12,
+	W_ID_AUDIT_ACCESS      = 13,
 	W_END
 };
 

--- a/src/runner.c
+++ b/src/runner.c
@@ -281,6 +281,10 @@ struct checks *register_checks(char level,
 			add_check(NODE_TUNABLE_POLICY, ck, "W-012",
 				  check_unknown_cond_id);
 		}
+		if (CHECK_ENABLED("W-013")) {
+			add_check(NODE_AV_RULE, ck, "W-013",
+				  check_audit_access_perm);
+		}
 		// FALLTHRU
 	case 'E':
 		if (CHECK_ENABLED("E-002")) {

--- a/src/te_checks.c
+++ b/src/te_checks.c
@@ -830,6 +830,26 @@ struct check_result *check_unknown_cond_id(__attribute__((unused)) const struct 
 	return NULL;
 }
 
+struct check_result *check_audit_access_perm(__attribute__((unused)) const struct
+                                            check_data *data,
+                                            const struct
+                                            policy_node *node)
+{
+	if (node->data.av_data->flavor == AV_RULE_DONTAUDIT ||
+	    node->data.av_data->flavor == AV_RULE_NEVERALLOW) {
+		return NULL;
+	}
+
+	for (const struct string_list *perms = node->data.av_data->perms; perms; perms = perms->next) {
+		if (0 == strcmp(perms->string, "audit_access")) {
+			return make_check_result('W', W_ID_AUDIT_ACCESS,
+						 "Allow rule with audit_access permission");
+		}
+	}
+
+	return NULL;
+}
+
 struct check_result *check_declaration_interface_nameclash(__attribute__((unused)) const struct check_data
 							   *data,
 							   const struct policy_node

--- a/src/te_checks.h
+++ b/src/te_checks.h
@@ -231,6 +231,18 @@ struct check_result *check_unknown_cond_id(const struct check_data
                                            *node);
 
 /*********************************************
+* Check for allow rule with audit_access permission
+* Called on NODE_AV_RULE nodes
+* data - metadata about the file
+* node - the node to check
+* returns NULL if passed or check_result for issue W-013
+*********************************************/
+struct check_result *check_audit_access_perm(const struct
+                                            check_data *data,
+                                            const struct
+                                            policy_node *node);
+
+/*********************************************
  * Check for clash of declaration and interface names.
  * This will cause macro expansion to enter an endless loop
  * and consume all available memory.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -186,6 +186,7 @@ FUNCTIONAL_TEST_FILES=functional/end-to-end.bats \
 			functional/policies/check_triggers/w11.te \
 			functional/policies/check_triggers/w11.if \
 			functional/policies/check_triggers/w12.te \
+			functional/policies/check_triggers/w13.te \
 			functional/policies/check_triggers/x01.if \
 			functional/policies/check_triggers/x01.te \
 			functional/policies/check_triggers/x02.te \

--- a/tests/functional/end-to-end.bats
+++ b/tests/functional/end-to-end.bats
@@ -277,6 +277,10 @@ test_report_format_impl() {
 	test_one_check "W-012" "w12.te"
 }
 
+@test "W-013" {
+	test_one_check_expect "W-013" "w13.te" 2
+}
+
 @test "E-002" {
 	test_one_check "E-002" "e02.fc"
 }

--- a/tests/functional/policies/check_triggers/w13.te
+++ b/tests/functional/policies/check_triggers/w13.te
@@ -1,0 +1,13 @@
+policy_module(w13, 1.0)
+
+type foo_t;
+
+# do not warn about these
+allow foo_t foo_t:file *;
+allow foo_t foo_t:dir ~map;
+dontaudit foo_t foo_t:chr_file audit_access;
+neverallow foo_t foo_t:sock_file audit_access;
+
+# warn about these
+allow foo_t foo_t:file audit_access;
+auditallow foo_t foo_t:lnk_file audit_access;


### PR DESCRIPTION
The audit_access permissions for the common file class has only an
affect in dontaudit rules (and to an extend in neverallow rules).
Warn about occurrences in allow and auditallow rules.

Refpolicy findings (due to usage in unconfined access):

    kernel.te:          551: (W): Allow rule with audit_access permission (W-013)
    kernel.te:          552: (W): Allow rule with audit_access permission (W-013)
    kernel.te:          553: (W): Allow rule with audit_access permission (W-013)
    kernel.te:          555: (W): Allow rule with audit_access permission (W-013)
    kernel.te:          556: (W): Allow rule with audit_access permission (W-013)
    kernel.te:          560: (W): Allow rule with audit_access permission (W-013)
    kernel.te:          561: (W): Allow rule with audit_access permission (W-013)
    kernel.te:          562: (W): Allow rule with audit_access permission (W-013)
    kernel.te:          563: (W): Allow rule with audit_access permission (W-013)
    kernel.te:          564: (W): Allow rule with audit_access permission (W-013)
    kernel.te:          565: (W): Allow rule with audit_access permission (W-013)
    kernel.te:          566: (W): Allow rule with audit_access permission (W-013)
    filesystem.te:      341: (W): Allow rule with audit_access permission (W-013)
    filesystem.te:      342: (W): Allow rule with audit_access permission (W-013)
    filesystem.te:      343: (W): Allow rule with audit_access permission (W-013)
    filesystem.te:      344: (W): Allow rule with audit_access permission (W-013)
    filesystem.te:      345: (W): Allow rule with audit_access permission (W-013)
    filesystem.te:      346: (W): Allow rule with audit_access permission (W-013)
    filesystem.te:      347: (W): Allow rule with audit_access permission (W-013)
    storage.te:          62: (W): Allow rule with audit_access permission (W-013)
    storage.te:          63: (W): Allow rule with audit_access permission (W-013)
    devices.te:         437: (W): Allow rule with audit_access permission (W-013)
    devices.te:         438: (W): Allow rule with audit_access permission (W-013)
    devices.te:         439: (W): Allow rule with audit_access permission (W-013)
    files.te:           230: (W): Allow rule with audit_access permission (W-013)
    files.te:           231: (W): Allow rule with audit_access permission (W-013)
    files.te:           232: (W): Allow rule with audit_access permission (W-013)
    files.te:           233: (W): Allow rule with audit_access permission (W-013)
    files.te:           234: (W): Allow rule with audit_access permission (W-013)
    files.te:           235: (W): Allow rule with audit_access permission (W-013)
    files.te:           236: (W): Allow rule with audit_access permission (W-013)
    Found the following issue counts:
    W-013: 31