### PR TITLE
RFC: Expand checks about requirements to userspace classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ tests/check_startup
 tests/check_te_checks
 tests/check_ordering
 tests/check_perm_macro
+tests/check_name_list
 tests/functional/policies/parse_errors/test3_tmp.if
 tests/functional/policies/parse_errors/test5_tmp.te
 tests/functional/policies/parse_errors/test6_tmp.if

--- a/README
+++ b/README
@@ -175,9 +175,9 @@ CHECK IDS
 	S-009: Permission macro suffix does not match class name
 	S-010: Permission macro usage suggested
 
-	W-001: Type or attribute referenced without explicit declaration
-	W-002: Type, attribute or role used but not listed in require block in interface
-	W-003: Unused type, attribute or role listed in require block
+	W-001: Type, attribute or userspace class referenced without explicit declaration
+	W-002: Type, attribute, role or userspace class used but not listed in require block in interface
+	W-003: Unused type, attribute, role or userspace class listed in require block
 	W-004: Potentially unescaped regex character in file contexts paths
 	W-005: Interface call from module not in optional_policy block
 	W-006: Interface call with empty argument

--- a/README
+++ b/README
@@ -201,3 +201,22 @@ CHECK IDS
 
 	F-001: Policy syntax error prevents further processing
 	F-002: Internal error in SELint
+
+REFERENCE POLICY CONVENTIONS
+
+	To improve the accuracy and avoid false-positives SELint makes some assumptions about
+	naming conventions and formatting of the policy:
+
+	* Type identifiers should end with the suffix '_t'.
+	* Role identifiers should end with the suffix '_r'.
+	* Names of noop interfaces for availability checks should end with the suffix '_stub'.
+	* Permission macros should end with the suffix '_perms'.
+	* Class set macros should end with the suffix '_class_set'.
+	* Security class declarations of userspace classes in the security_classes file should be
+	  declared with a comment including the word 'userspace'.
+	* Interfaces that wrap a file based type-transition should end with the suffix '_filetrans'.
+	* Interfaces that transforms their arguments, e.g. associate an attribute with them,
+	  and thus should be handled like a declaration should have one of the following common
+	  suffixes: '_type', '_file', '_domain', '_node', '_agent', '_delivery', '_sender',
+	  '_boolean', '_content', '_constrained', '_executable', '_exemption', '_object'
+	  or '_mountpoint'.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 bin_PROGRAMS = selint
-selint_SOURCES = main.c lex.l parse.y tree.c tree.h selint_error.h parse_functions.c parse_functions.h maps.c maps.h runner.c runner.h parse_fc.c parse_fc.h template.c template.h file_list.c file_list.h check_hooks.c check_hooks.h fc_checks.c fc_checks.h util.c util.h if_checks.c if_checks.h selint_config.c selint_config.h string_list.c string_list.h startup.c startup.h te_checks.c te_checks.h ordering.c ordering.h color.c color.h perm_macro.c perm_macro.h xalloc.h
+selint_SOURCES = main.c lex.l parse.y tree.c tree.h selint_error.h parse_functions.c parse_functions.h maps.c maps.h runner.c runner.h parse_fc.c parse_fc.h template.c template.h file_list.c file_list.h check_hooks.c check_hooks.h fc_checks.c fc_checks.h util.c util.h if_checks.c if_checks.h selint_config.c selint_config.h string_list.c string_list.h startup.c startup.h te_checks.c te_checks.h ordering.c ordering.h color.c color.h perm_macro.c perm_macro.h xalloc.h name_list.c name_list.h
 BUILT_SOURCES = parse.h
 AM_YFLAGS = -d -Wno-yacc -Werror=conflicts-rr -Werror=conflicts-sr
 

--- a/src/if_checks.c
+++ b/src/if_checks.c
@@ -330,6 +330,9 @@ struct check_result *check_name_used_but_not_required_in_if(const struct
 				flavor = "Role Attribute";
 			} else if (name_is_role(ndata) && look_up_in_decl_map(ndata->name, DECL_ROLE)) {
 				flavor = "Role";
+			} else if (name_is_class(ndata) && look_up_in_decl_map(ndata->name, DECL_CLASS) &&
+			           userspace_class_support && is_userspace_class(ndata->name, ndata->traits)) {
+				flavor = "Class";
 			} else {
 				// This is a string we don't recognize.  Other checks and/or
 				// the compiler catch invalid bare words
@@ -374,6 +377,14 @@ struct check_result *check_name_required_but_not_used_in_if(const struct
 		flavor = "Role Attribute";
 	} else if (dd->flavor == DECL_ROLE) {
 		flavor = "Role";
+	} else if (dd->flavor == DECL_CLASS && userspace_class_support) {
+		flavor = "Class";
+		if (!is_userspace_class(dd->name, dd->attrs)) {
+			return make_check_result('W',
+			                         W_ID_UNUSED_REQ,
+			                         "Class %s is listed in require block but is not a userspace class",
+			                         dd->name);
+		}
 	} else {
 		return NULL;
 	}
@@ -400,7 +411,7 @@ struct check_result *check_name_required_but_not_used_in_if(const struct
 		return NULL;
 	}
 
-	struct name_list *names_to_check = get_names_in_node(node);
+	struct name_list *names_to_check = names_to_check = get_names_in_node(node);
 	if (!names_to_check) {
 		// This should never happen
 		return alloc_internal_error(

--- a/src/maps.h
+++ b/src/maps.h
@@ -29,6 +29,12 @@ struct hash_elem {
 	               hh_class, hh_perm, hh_mods, hh_mod_layers;
 };
 
+struct bool_hash_elem {
+	char *key;
+	int val;
+	UT_hash_handle hh_userspace_class;
+};
+
 struct sl_hash_elem {
 	char *key;
 	struct string_list *val;
@@ -70,6 +76,12 @@ const char *look_up_in_mod_layers_map(const char *mod_name);
 void insert_into_ifs_map(const char *if_name, const char *mod_name);
 
 const char *look_up_in_ifs_map(const char *if_name);
+
+void mark_userspace_class(const char *class_name);
+
+int is_userspace_class(const char *class_name, const struct string_list *permissions);
+
+extern int userspace_class_support;
 
 void mark_transform_if(const char *if_name);
 

--- a/src/name_list.c
+++ b/src/name_list.c
@@ -1,0 +1,222 @@
+/*
+* Copyright 2022 The SELint Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "name_list.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "tree.h"
+#include "xalloc.h"
+
+static bool is_compatible(enum name_flavor a, enum name_flavor b)
+{
+	if (b == NAME_UNKNOWN) {
+		return true;
+	}
+
+	switch (a) {
+	case NAME_TYPE:
+		return b == NAME_TYPE || b == NAME_TYPE_OR_ATTRIBUTE;
+	case NAME_TYPEATTRIBUTE:
+		return b == NAME_TYPEATTRIBUTE || b == NAME_TYPE_OR_ATTRIBUTE;
+	case NAME_TYPE_OR_ATTRIBUTE:
+		return b == NAME_TYPE || b == NAME_TYPEATTRIBUTE || b == NAME_TYPE_OR_ATTRIBUTE;
+	case NAME_ROLE:
+		return b == NAME_ROLE || b == NAME_ROLE_OR_ATTRIBUTE;
+	case NAME_ROLEATTRIBUTE:
+		return b == NAME_ROLEATTRIBUTE || b == NAME_ROLE_OR_ATTRIBUTE;
+	case NAME_ROLE_OR_ATTRIBUTE:
+		return b == NAME_ROLE || b == NAME_ROLEATTRIBUTE || b == NAME_ROLE_OR_ATTRIBUTE;
+	case NAME_CLASS:
+		return b == NAME_CLASS;
+	case NAME_PERM:
+		return b == NAME_PERM;
+	case NAME_USER:
+		return b == NAME_USER;
+	case NAME_BOOL:
+		return b == NAME_BOOL;
+	case NAME_UNKNOWN:
+		return true;
+	default:
+		// should never happen
+		return 0;
+	}
+}
+
+bool name_is_type(const struct name_data *name)
+{
+	return is_compatible(name->flavor, NAME_TYPE);
+}
+
+bool name_is_typeattr(const struct name_data *name)
+{
+	return is_compatible(name->flavor, NAME_TYPEATTRIBUTE);
+}
+
+bool name_is_role(const struct name_data *name)
+{
+	return is_compatible(name->flavor, NAME_ROLE);
+}
+
+bool name_is_roleattr(const struct name_data *name)
+{
+	return is_compatible(name->flavor, NAME_ROLEATTRIBUTE);
+}
+
+bool name_is_class(const struct name_data *name)
+{
+	return is_compatible(name->flavor, NAME_CLASS);
+}
+
+bool name_list_contains_name(const struct name_list *nl, const struct name_data *name)
+{
+	for (;nl; nl = nl->next) {
+		if (!is_compatible(nl->data->flavor, name->flavor)) {
+			continue;
+		}
+
+		if (0 == strcmp(nl->data->name, name->name)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+struct name_list *name_list_from_sl_with_traits(const struct string_list *sl,
+                                                enum name_flavor flavor,
+                                                const struct string_list *traits)
+{
+	if (!sl) {
+		return NULL;
+	}
+	struct name_list *ret = xmalloc(sizeof(struct name_list));
+	struct name_list *cur = ret;
+
+	while (sl) {
+		struct name_data *data = xmalloc(sizeof(struct name_data));
+		data->name = xstrdup(sl->string);
+		data->flavor = flavor;
+		data->traits = copy_string_list(traits);
+		cur->data = data;
+
+		if (sl->next) {
+			cur->next = xmalloc(sizeof(struct name_list));
+		} else {
+			cur->next = NULL;
+		}
+		sl = sl->next;
+		cur = cur->next;
+	}
+	return ret;
+}
+
+struct name_list *name_list_create(const char *name, enum name_flavor flavor)
+{
+	struct name_data *data = xmalloc(sizeof(struct name_data));
+	data->name = xstrdup(name);
+	data->flavor = flavor;
+	data->traits = NULL;
+	struct name_list *ret = xmalloc(sizeof(struct name_list));
+	ret->data = data;
+	ret->next = NULL;
+
+	return ret;
+}
+
+struct name_list *name_list_from_decl(const struct declaration_data *decl)
+{
+	struct name_data *data = xmalloc(sizeof(struct name_data));
+	data->name = xstrdup(decl->name);
+	data->traits = NULL;
+
+	struct name_list *extra = NULL;
+
+	switch (decl->flavor) {
+	case DECL_TYPE:
+		data->flavor = NAME_TYPE;
+		extra = name_list_from_sl(decl->attrs, NAME_TYPEATTRIBUTE);
+		break;
+	case DECL_ATTRIBUTE:
+		data->flavor = NAME_TYPEATTRIBUTE;
+		break;
+	case DECL_ATTRIBUTE_ROLE:
+		data->flavor = NAME_ROLEATTRIBUTE;
+		break;
+	case DECL_ROLE:
+		data->flavor = NAME_ROLE;
+		break;
+	case DECL_USER:
+		data->flavor = NAME_USER;
+		break;
+	case DECL_CLASS:
+		data->flavor = NAME_CLASS;
+		data->traits = copy_string_list(decl->attrs);
+		break;
+	case DECL_PERM:
+		data->flavor = NAME_PERM;
+		break;
+	case DECL_BOOL:
+		data->flavor = NAME_BOOL;
+		break;
+	default:
+		// should never happen
+		data->flavor = NAME_UNKNOWN;
+		break;
+	}
+
+	struct name_list *ret = xmalloc(sizeof(struct name_list));
+	ret->data = data;
+	ret->next = extra;
+
+	return ret;
+}
+
+struct name_list *concat_name_lists(struct name_list *head, struct name_list *tail)
+{
+	if (!head) {
+		return tail;
+	}
+
+	if (!tail) {
+		return head;
+	}
+
+	struct name_list *cur = head;
+	while (cur->next) {
+		cur = cur->next;
+	}
+	cur->next = tail;
+
+	return head;
+}
+
+void free_name_list(struct name_list *nl)
+{
+	if (nl == NULL) {
+		return;
+	}
+	struct name_list *cur = nl;
+
+	while (cur) {
+		struct name_list *to_free = cur;
+		cur = cur->next;
+		free(to_free->data->name);
+		free_string_list(to_free->data->traits);
+		free(to_free->data);
+		free(to_free);
+	}
+}

--- a/src/name_list.h
+++ b/src/name_list.h
@@ -1,0 +1,83 @@
+/*
+* Copyright 2022 The SELint Contributors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef NAME_LIST_H
+#define NAME_LIST_H
+
+#include <stdbool.h>
+
+#include "string_list.h"
+// avoid circular include with tree.h
+struct declaration_data;
+
+
+enum name_flavor {
+	NAME_UNKNOWN,
+	NAME_TYPE,
+	NAME_TYPEATTRIBUTE,
+	NAME_TYPE_OR_ATTRIBUTE,
+	NAME_ROLE,
+	NAME_ROLEATTRIBUTE,
+	NAME_ROLE_OR_ATTRIBUTE,
+	NAME_CLASS,
+	NAME_PERM,
+	NAME_USER,
+	NAME_BOOL,
+};
+
+struct name_data {
+	enum name_flavor flavor;
+	char *name;
+	// flavor == NAME_CLASS: list of associated permissions
+	struct string_list *traits;
+};
+
+bool name_is_type(const struct name_data *name);
+bool name_is_typeattr(const struct name_data *name);
+bool name_is_role(const struct name_data *name);
+bool name_is_roleattr(const struct name_data *name);
+bool name_is_class(const struct name_data *name);
+
+struct name_list {
+	struct name_data *data;
+	struct name_list *next;
+};
+
+// Create a name list with a single entry
+struct name_list *name_list_create(const char *name, enum name_flavor flavor);
+
+// Create a name list with identifiers from a string list and associate all with flavor
+struct name_list *name_list_from_sl_with_traits(const struct string_list *sl,
+                                                enum name_flavor flavor,
+                                                const struct string_list *traits);
+static inline struct name_list *name_list_from_sl(const struct string_list *sl,
+                                                  enum name_flavor flavor)
+{
+	return name_list_from_sl_with_traits(sl, flavor, NULL);
+}
+
+// Concat two name lists, accepts NULL lists.
+// Note: freeing the returned list will free both original name lists
+struct name_list *concat_name_lists(struct name_list *head, struct name_list *tail);
+
+// Create a name list with a single entry from a declaration
+struct name_list *name_list_from_decl(const struct declaration_data *decl);
+
+bool name_list_contains_name(const struct name_list *nl, const struct name_data *name);
+
+void free_name_list(struct name_list *nl);
+
+#endif

--- a/src/ordering.c
+++ b/src/ordering.c
@@ -358,21 +358,21 @@ static bool is_own_module_rule(const struct policy_node *node, const char *curre
 			return false;
 		}
 	}
-	struct string_list *names = get_names_in_node(node);
-	struct string_list *cur = names;
+	struct name_list *names = get_names_in_node(node);
+	const struct name_list *cur = names;
 	while (cur) {
-		const char *module_of_type_or_attr = look_up_in_decl_map(cur->string, DECL_TYPE);
+		const char *module_of_type_or_attr = look_up_in_decl_map(cur->data->name, DECL_TYPE);
 		if (!module_of_type_or_attr) {
-			module_of_type_or_attr = look_up_in_decl_map(cur->string, DECL_ATTRIBUTE);
+			module_of_type_or_attr = look_up_in_decl_map(cur->data->name, DECL_ATTRIBUTE);
 		}
 		if (module_of_type_or_attr &&
 		    0 != strcmp(module_of_type_or_attr, current_mod_name)) {
-			free_string_list(names);
+			free_name_list(names);
 			return false;
 		}
 		cur = cur->next;
 	}
-	free_string_list(names);
+	free_name_list(names);
 	// This assumes that not found strings are not types from other modules.
 	// This is probably necessary because we'll find strings like "file" or
 	// "read_file_perms" for example.  However, in normal mode without context

--- a/src/startup.h
+++ b/src/startup.h
@@ -25,6 +25,8 @@ enum selint_error load_access_vectors_kernel(const char *av_path);
 
 enum selint_error load_access_vectors_source(const char *av_path);
 
+enum selint_error load_security_classes_source(const char *sec_class_path);
+
 void load_modules_normal(void);
 
 enum selint_error load_modules_source(const char *modules_conf_path);

--- a/src/tree.h
+++ b/src/tree.h
@@ -17,6 +17,7 @@
 #ifndef TREE_H
 #define TREE_H
 
+#include "name_list.h"
 #include "selint_error.h"
 #include "string_list.h"
 
@@ -241,9 +242,9 @@ int is_template_call(const struct policy_node *node);
 
 const char *get_name_if_in_template(const struct policy_node *cur);
 
-struct string_list *get_names_in_node(const struct policy_node *node);
+struct name_list *get_names_in_node(const struct policy_node *node);
 
-struct string_list *get_names_required(const struct policy_node *node);
+struct name_list *get_names_required(const struct policy_node *node);
 
 const char *decl_flavor_to_string(enum decl_flavor flavor);
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -150,6 +150,7 @@ FUNCTIONAL_TEST_FILES=functional/end-to-end.bats \
 			functional/policies/check_triggers/e10.warn.te \
 			functional/policies/check_triggers/modules.conf \
 			functional/policies/check_triggers/obj_perm_sets.spt \
+			functional/policies/check_triggers/security_classes \
 			functional/policies/check_triggers/s01.te \
 			functional/policies/check_triggers/s02.fc \
 			functional/policies/check_triggers/s02_other.te \
@@ -168,7 +169,11 @@ FUNCTIONAL_TEST_FILES=functional/end-to-end.bats \
 			functional/policies/check_triggers/w02_role.te \
 			functional/policies/check_triggers/w02.te \
 			functional/policies/check_triggers/w02.bad_if.if \
+			functional/policies/check_triggers/w02_system_nowarn.if \
+			functional/policies/check_triggers/w02_system_warn.if \
 			functional/policies/check_triggers/w03_alias.if \
+			functional/policies/check_triggers/w03_system_nowarn.if \
+			functional/policies/check_triggers/w03_system_warn.if \
 			functional/policies/check_triggers/w03.if \
 			functional/policies/check_triggers/w03_role.if \
 			functional/policies/check_triggers/w03_stub.if \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,7 +15,7 @@
 @VALGRIND_CHECK_RULES@
 VALGRIND_memcheck_FLAGS=--leak-check=full --show-reachable=yes --show-leak-kinds=all --errors-for-leak-kinds=all
 
-TESTS = check_tree check_parse_functions check_maps check_parsing check_parse_fc check_template check_file_list check_fc_checks check_check_hooks check_selint_config check_if_checks check_string_list check_runner check_startup check_te_checks check_ordering check_perm_macro
+TESTS = check_tree check_parse_functions check_maps check_parsing check_parse_fc check_template check_file_list check_fc_checks check_check_hooks check_selint_config check_if_checks check_string_list check_runner check_startup check_te_checks check_ordering check_perm_macro check_name_list
 check_PROGRAMS = ${TESTS}
 
 AV_FILE_PERM_FILES=sample_av/file/index \
@@ -286,14 +286,16 @@ UTIL_OBJS=$(top_builddir)/src/util.o
 SELINT_ERROR_HEADS=$(top_builddir)/src/selint_error.h
 STRING_LIST_HEADS=$(top_builddir)/src/string_list.h ${SELINT_ERROR_HEADS}
 STRING_LIST_OBJS=$(top_builddir)/src/string_list.o
+NAME_LIST_HEADS=$(top_builddir)/src/name_list.h
+NAME_LIST_OBJS=$(top_builddir)/src/name_list.o ${STRING_LIST_OBJS}
 COLOR_HEADS=$(top_builddir)/src/color.h
 COLOR_OBJS=$(top_builddir)/src/color.o
 PERM_MACRO_HEADS=$(top_builddir)/src/perm_macro.h ${UTIL_HEADS} ${COLOR_HEADS}
 PERM_MACRO_OBJS=$(top_builddir)/src/perm_macro.o ${UTIL_OBJS} ${COLOR_OBJS}
 SELINT_CONFIG_HEADS=$(top_builddir)/src/selint_config.h ${STRING_LIST_HEADS} ${TREE_HEADS} ${MAPS_HEADS} ${ORDERING_HEADS}
 SELINT_CONFIG_OBJS=$(top_builddir)/src/selint_config.o ${STRING_LIST_OBJS} ${TREE_OBJS} ${MAPS_OBJS} ${UTIL_OBJS}
-TREE_HEADS=$(top_builddir)/src/tree.h ${STRING_LIST_HEADS}
-TREE_OBJS=$(top_builddir)/src/tree.o ${STRING_LIST_OBJS} $(top_builddir)/src/maps.o
+TREE_HEADS=$(top_builddir)/src/tree.h ${STRING_LIST_HEADS} ${NAME_LIST_HEADS}
+TREE_OBJS=$(top_builddir)/src/tree.o ${NAME_LIST_OBJS} $(top_builddir)/src/maps.o
 FILE_LIST_HEADS=$(top_builddir)/src/file_list.h ${TREE_HEADS}
 FILE_LIST_OBJS=$(top_builddir)/src/file_list.o ${TREE_OBJS}
 MAPS_HEADS=$(top_builddir)/src/maps.h ${SELINT_ERROR_HEADS} ${TREE_HEADS}
@@ -323,6 +325,9 @@ ORDERING_OBJS=$(top_builddir)/src/ordering.o ${TREE_OBJS} ${MAPS_OBJS}
 
 check_string_list_SOURCES = check_string_list.c ${STRING_LIST_HEADS}
 check_string_list_LDADD = @CHECK_LIBS@ $(sort ${STRING_LIST_OBJS})
+
+check_name_list_SOURCES = check_name_list.c ${NAME_LIST_HEADS}
+check_name_list_LDADD = @CHECK_LIBS@ $(sort ${NAME_LIST_OBJS})
 
 check_selint_config_SOURCES = check_selint_config.c ${SELINT_CONFIG_HEADS} ${STRING_LIST_HEADS}
 check_selint_config_LDADD = @CHECK_LIBS@ $(sort ${SELINT_CONFIG_OBJS} ${STRING_LIST_OBJS})

--- a/tests/check_name_list.c
+++ b/tests/check_name_list.c
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2022 The SELint Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <check.h>
+#include <stdlib.h>
+
+#include "../src/name_list.h"
+#include "../src/tree.h"
+
+START_TEST (test_name_list_create) {
+
+	struct name_list *nl = name_list_create("foo", NAME_ROLEATTRIBUTE);
+
+	ck_assert_ptr_nonnull(nl);
+	ck_assert_ptr_nonnull(nl->data);
+	ck_assert_str_eq("foo", nl->data->name);
+	ck_assert_int_eq(NAME_ROLEATTRIBUTE, nl->data->flavor);
+	ck_assert_ptr_null(nl->data->traits);
+	ck_assert_ptr_null(nl->next);
+
+	free_name_list(nl);
+
+}
+END_TEST
+
+START_TEST (test_name_list_from_sl) {
+
+	struct string_list *sl, *traits;
+	struct name_list *nl;
+
+	sl = NULL;
+	nl = name_list_from_sl_with_traits(sl, NAME_TYPE, NULL);
+	ck_assert_ptr_null(nl);
+
+	sl = sl_from_strs(2, "foo", "bar");
+	nl = name_list_from_sl_with_traits(sl, NAME_TYPE, NULL);
+
+	ck_assert_ptr_nonnull(nl);
+	ck_assert_ptr_nonnull(nl->data);
+	ck_assert_str_eq("foo", nl->data->name);
+	ck_assert_int_eq(NAME_TYPE, nl->data->flavor);
+	ck_assert_ptr_null(nl->data->traits);
+
+	ck_assert_ptr_nonnull(nl->next);
+	ck_assert_str_eq("bar", nl->next->data->name);
+	ck_assert_int_eq(NAME_TYPE, nl->next->data->flavor);
+	ck_assert_ptr_null(nl->next->data->traits);
+	ck_assert_ptr_null(nl->next->next);
+
+	free_name_list(nl);
+	free_string_list(sl);
+
+	sl = sl_from_strs(3, "foo", "bar", "baz");
+	traits = sl_from_strs(2, "alpha", "beta");
+	nl = name_list_from_sl_with_traits(sl, NAME_ROLE, traits);
+
+	ck_assert_ptr_nonnull(nl);
+	ck_assert_ptr_nonnull(nl->data);
+	ck_assert_str_eq("foo", nl->data->name);
+	ck_assert_int_eq(NAME_ROLE, nl->data->flavor);
+	ck_assert_ptr_nonnull(nl->data->traits);
+	ck_assert_str_eq("alpha", nl->data->traits->string);
+	ck_assert_str_eq("beta", nl->data->traits->next->string);
+	ck_assert_ptr_null(nl->data->traits->next->next);
+
+	ck_assert_ptr_nonnull(nl->next);
+	ck_assert_ptr_nonnull(nl->next->data);
+	ck_assert_str_eq("bar", nl->next->data->name);
+	ck_assert_int_eq(NAME_ROLE, nl->next->data->flavor);
+	ck_assert_ptr_nonnull(nl->next->data->traits);
+	ck_assert_str_eq("alpha", nl->next->data->traits->string);
+	ck_assert_str_eq("beta", nl->next->data->traits->next->string);
+	ck_assert_ptr_null(nl->next->data->traits->next->next);
+
+	ck_assert_ptr_nonnull(nl->next->next);
+	ck_assert_ptr_nonnull(nl->next->next->data);
+	ck_assert_str_eq("baz", nl->next->next->data->name);
+	ck_assert_int_eq(NAME_ROLE, nl->next->next->data->flavor);
+	ck_assert_ptr_nonnull(nl->next->next->data->traits);
+	ck_assert_str_eq("alpha", nl->next->next->data->traits->string);
+	ck_assert_str_eq("beta", nl->next->next->data->traits->next->string);
+	ck_assert_ptr_null(nl->next->next->data->traits->next->next);
+
+	ck_assert_ptr_null(nl->next->next->next);
+
+	free_name_list(nl);
+	free_string_list(traits);
+	free_string_list(sl);
+
+}
+END_TEST
+
+START_TEST (test_concat_name_lists) {
+
+	struct name_list *res, *nl1, *nl2;
+
+	ck_assert_ptr_null(concat_name_lists(NULL, NULL));
+
+	nl1 = name_list_create("hello", NAME_TYPEATTRIBUTE);
+	ck_assert_ptr_nonnull(nl1);
+
+	nl2 = name_list_create("world", NAME_CLASS);
+	ck_assert_ptr_nonnull(nl2);
+
+	res = concat_name_lists(NULL, nl1);
+	ck_assert_ptr_nonnull(res);
+	ck_assert_str_eq("hello", res->data->name);
+	ck_assert_int_eq(NAME_TYPEATTRIBUTE, res->data->flavor);
+	ck_assert_ptr_null(res->next);
+
+	res = concat_name_lists(nl1, NULL);
+	ck_assert_ptr_nonnull(res);
+	ck_assert_str_eq("hello", res->data->name);
+	ck_assert_int_eq(NAME_TYPEATTRIBUTE, res->data->flavor);
+	ck_assert_ptr_null(res->next);
+
+	res = concat_name_lists(nl1, nl2);
+	ck_assert_ptr_nonnull(res);
+	ck_assert_str_eq("hello", res->data->name);
+	ck_assert_int_eq(NAME_TYPEATTRIBUTE, res->data->flavor);
+	ck_assert_ptr_nonnull(res->next);
+	ck_assert_str_eq("world", res->next->data->name);
+	ck_assert_int_eq(NAME_CLASS, res->next->data->flavor);
+	ck_assert_ptr_null(res->next->next);
+
+	free_name_list(res); // frees nl1 and nl2
+
+}
+END_TEST
+
+START_TEST (test_name_lists_from_type_decl) {
+
+	struct declaration_data *decl = malloc(sizeof(struct declaration_data));
+	decl->flavor = DECL_TYPE;
+	decl->name = strdup("foo");
+	decl->attrs = sl_from_strs(2, "alpha", "beta");
+
+	struct name_list *nl = name_list_from_decl(decl);
+
+	free_string_list(decl->attrs);
+	free(decl->name);
+	free(decl);
+
+	ck_assert_ptr_nonnull(nl);
+	ck_assert_ptr_nonnull(nl->data);
+	ck_assert_str_eq("foo", nl->data->name);
+	ck_assert_int_eq(NAME_TYPE, nl->data->flavor);
+	ck_assert_ptr_null(nl->data->traits);
+
+	ck_assert_ptr_nonnull(nl->next);
+	ck_assert_ptr_nonnull(nl->next->data);
+	ck_assert_str_eq("alpha", nl->next->data->name);
+	ck_assert_int_eq(NAME_TYPEATTRIBUTE, nl->next->data->flavor);
+	ck_assert_ptr_null(nl->next->data->traits);
+
+	ck_assert_ptr_nonnull(nl->next->next);
+	ck_assert_ptr_nonnull(nl->next->next->data);
+	ck_assert_str_eq("beta", nl->next->next->data->name);
+	ck_assert_int_eq(NAME_TYPEATTRIBUTE, nl->next->next->data->flavor);
+	ck_assert_ptr_null(nl->next->next->data->traits);
+
+	ck_assert_ptr_null(nl->next->next->next);
+
+	free_name_list(nl);
+
+}
+END_TEST
+
+START_TEST (test_name_lists_from_class_decl) {
+
+	struct declaration_data *decl = malloc(sizeof(struct declaration_data));
+	decl->flavor = DECL_CLASS;
+	decl->name = strdup("foo");
+	decl->attrs = sl_from_strs(2, "alpha", "beta");
+
+	struct name_list *nl = name_list_from_decl(decl);
+
+	free_string_list(decl->attrs);
+	free(decl->name);
+	free(decl);
+
+	ck_assert_ptr_nonnull(nl);
+	ck_assert_ptr_nonnull(nl->data);
+	ck_assert_str_eq("foo", nl->data->name);
+	ck_assert_int_eq(NAME_CLASS, nl->data->flavor);
+	ck_assert_ptr_nonnull(nl->data->traits);
+	ck_assert_str_eq("alpha", nl->data->traits->string);
+	ck_assert_str_eq("beta", nl->data->traits->next->string);
+	ck_assert_ptr_null(nl->data->traits->next->next);
+
+	ck_assert_ptr_null(nl->next);
+
+	free_name_list(nl);
+
+}
+END_TEST
+
+START_TEST (test_name_list_contains) {
+
+	struct name_list *d;
+	struct name_list *nl = concat_name_lists(
+		name_list_create("foo", NAME_TYPEATTRIBUTE),
+		name_list_create("bar", NAME_ROLE));
+
+	ck_assert_ptr_nonnull(nl);
+
+	d = name_list_create("foo", NAME_TYPEATTRIBUTE);
+	ck_assert_int_eq(1, name_list_contains_name(nl, d->data));
+	free_name_list(d);
+
+	d = name_list_create("foo", NAME_TYPE_OR_ATTRIBUTE);
+	ck_assert_int_eq(1, name_list_contains_name(nl, d->data));
+	free_name_list(d);
+
+	d = name_list_create("foo", NAME_UNKNOWN);
+	ck_assert_int_eq(1, name_list_contains_name(nl, d->data));
+	free_name_list(d);
+
+	d = name_list_create("foo", NAME_TYPE);
+	ck_assert_int_eq(0, name_list_contains_name(nl, d->data));
+	free_name_list(d);
+
+	d = name_list_create("foo", NAME_BOOL);
+	ck_assert_int_eq(0, name_list_contains_name(nl, d->data));
+	free_name_list(d);
+
+	d = name_list_create("bar", NAME_ROLE);
+	ck_assert_int_eq(1, name_list_contains_name(nl, d->data));
+	free_name_list(d);
+
+	d = name_list_create("bar", NAME_ROLE_OR_ATTRIBUTE);
+	ck_assert_int_eq(1, name_list_contains_name(nl, d->data));
+	free_name_list(d);
+
+	d = name_list_create("bar", NAME_UNKNOWN);
+	ck_assert_int_eq(1, name_list_contains_name(nl, d->data));
+	free_name_list(d);
+
+	d = name_list_create("bar", NAME_ROLEATTRIBUTE);
+	ck_assert_int_eq(0, name_list_contains_name(nl, d->data));
+	free_name_list(d);
+
+	d = name_list_create("bar", NAME_TYPE);
+	ck_assert_int_eq(0, name_list_contains_name(nl, d->data));
+	free_name_list(d);
+
+	free_name_list(nl);
+
+}
+END_TEST
+
+static Suite *name_list_suite(void) {
+	Suite *s;
+	TCase *tc_core;
+
+	s = suite_create("Name_list");
+
+	tc_core = tcase_create("Core");
+
+	tcase_add_test(tc_core, test_name_list_create);
+	tcase_add_test(tc_core, test_name_list_from_sl);
+	tcase_add_test(tc_core, test_concat_name_lists);
+	tcase_add_test(tc_core, test_name_lists_from_type_decl);
+	tcase_add_test(tc_core, test_name_lists_from_class_decl);
+	tcase_add_test(tc_core, test_name_list_contains);
+	suite_add_tcase(s, tc_core);
+
+	return s;
+}
+
+int main(void) {
+
+	int number_failed = 0;
+	Suite *s;
+	SRunner *sr;
+
+	s = name_list_suite();
+	sr = srunner_create(s);
+	srunner_run_all(sr, CK_NORMAL);
+	number_failed = srunner_ntests_failed(sr);
+	srunner_free(sr);
+
+	return (number_failed == 0)? 0 : -1;
+}

--- a/tests/check_tree.c
+++ b/tests/check_tree.c
@@ -108,26 +108,35 @@ START_TEST (test_get_types_in_node_av) {
 
 	node->data.av_data = make_example_av_rule();
 
-	struct string_list *out = get_names_in_node(node);
+	struct name_list *out = get_names_in_node(node);
 
-	struct string_list *cur = out;
+	struct name_list *cur = out;
 
 	ck_assert_ptr_nonnull(cur);
-	ck_assert_str_eq(cur->string, EXAMPLE_TYPE_1);
+	ck_assert_str_eq(cur->data->name, EXAMPLE_TYPE_1);
+	ck_assert_int_eq(cur->data->flavor, NAME_TYPE_OR_ATTRIBUTE);
 
 	cur = cur->next;
 
 	ck_assert_ptr_nonnull(cur);
-	ck_assert_str_eq(cur->string, EXAMPLE_TYPE_2);
+	ck_assert_str_eq(cur->data->name, EXAMPLE_TYPE_2);
+	ck_assert_int_eq(cur->data->flavor, NAME_TYPE_OR_ATTRIBUTE);
 
 	cur = cur->next;
 
 	ck_assert_ptr_nonnull(cur);
-	ck_assert_str_eq(cur->string, EXAMPLE_TYPE_3);
+	ck_assert_str_eq(cur->data->name, EXAMPLE_TYPE_3);
+	ck_assert_int_eq(cur->data->flavor, NAME_TYPE_OR_ATTRIBUTE);
+
+	cur = cur->next;
+
+	ck_assert_ptr_nonnull(cur);
+	ck_assert_str_eq(cur->data->name, "file");
+	ck_assert_int_eq(cur->data->flavor, NAME_CLASS);
 
 	ck_assert_ptr_null(cur->next);
 
-	free_string_list(out);
+	free_name_list(out);
 	free_policy_node(node);
 }
 END_TEST
@@ -149,26 +158,29 @@ START_TEST (test_get_types_in_node_tt) {
 
 	tt_data->default_type = strdup(EXAMPLE_TYPE_1);
 
-	struct string_list *out = get_names_in_node(node);
+	struct name_list *out = get_names_in_node(node);
 
-	struct string_list *cur = out;
+	struct name_list *cur = out;
 
 	ck_assert_ptr_nonnull(cur);
-	ck_assert_str_eq(cur->string, EXAMPLE_TYPE_3);
+	ck_assert_str_eq(cur->data->name, EXAMPLE_TYPE_3);
+	ck_assert_int_eq(cur->data->flavor, NAME_TYPE_OR_ATTRIBUTE);
 
 	cur = cur->next;
 
 	ck_assert_ptr_nonnull(cur);
-	ck_assert_str_eq(cur->string, EXAMPLE_TYPE_2);
+	ck_assert_str_eq(cur->data->name, EXAMPLE_TYPE_2);
+	ck_assert_int_eq(cur->data->flavor, NAME_TYPE_OR_ATTRIBUTE);
 
 	cur = cur->next;
 
 	ck_assert_ptr_nonnull(cur);
-	ck_assert_str_eq(cur->string, EXAMPLE_TYPE_1);
+	ck_assert_str_eq(cur->data->name, EXAMPLE_TYPE_1);
+	ck_assert_int_eq(cur->data->flavor, NAME_TYPE);
 
 	ck_assert_ptr_null(cur->next);
 
-	free_string_list(out);
+	free_name_list(out);
 	free_policy_node(node);
 }
 END_TEST
@@ -184,15 +196,16 @@ START_TEST (test_get_types_in_node_dd) {
 
 	d_data->name = strdup(EXAMPLE_TYPE_2);
 
-	struct string_list *out = get_names_in_node(node);
+	struct name_list *out = get_names_in_node(node);
 
 	ck_assert_ptr_nonnull(out);
 
-	ck_assert_str_eq(out->string, EXAMPLE_TYPE_2);
+	ck_assert_str_eq(out->data->name, EXAMPLE_TYPE_2);
+	ck_assert_int_eq(out->data->flavor, NAME_TYPE);
 
 	ck_assert_ptr_null(out->next);
 
-	free_string_list(out);
+	free_name_list(out);
 	free_policy_node(node);
 }
 END_TEST
@@ -212,16 +225,18 @@ START_TEST (test_get_types_in_node_if_call) {
 	if_data->args->next = calloc(1, sizeof(struct string_list));
 	if_data->args->next->string = strdup("baz_t");
 
-	struct string_list *out = get_names_in_node(node);
+	struct name_list *out = get_names_in_node(node);
 
 	ck_assert_ptr_nonnull(out);
 
-	ck_assert_str_eq(out->string, "bar_t");
-	ck_assert_str_eq(out->next->string, "baz_t");
+	ck_assert_str_eq(out->data->name, "bar_t");
+	ck_assert_int_eq(out->data->flavor, NAME_UNKNOWN);
+	ck_assert_str_eq(out->next->data->name, "baz_t");
+	ck_assert_int_eq(out->next->data->flavor, NAME_UNKNOWN);
 
 	ck_assert_ptr_null(out->next->next);
 
-	free_string_list(out);
+	free_name_list(out);
 	free_policy_node(node);
 }
 END_TEST
@@ -247,14 +262,16 @@ START_TEST (test_get_types_in_node_exclusion) {
 	node->data.av_data->sources->next = calloc(1, sizeof(struct string_list));
 	node->data.av_data->sources->next->string = strdup("-init_t");
 
-	struct string_list *out = get_names_in_node(node);
+	struct name_list *out = get_names_in_node(node);
 	ck_assert_ptr_nonnull(out);
 
-	ck_assert_str_eq(out->string, "domain");
-	ck_assert_str_eq(out->next->string, "init_t"); // Strip "-"
+	ck_assert_str_eq(out->data->name, "domain");
+	ck_assert_int_eq(out->data->flavor, NAME_TYPE_OR_ATTRIBUTE);
+	ck_assert_str_eq(out->next->data->name, "init_t"); // Strip "-"
+	ck_assert_int_eq(out->next->data->flavor, NAME_TYPE_OR_ATTRIBUTE);
 	ck_assert_ptr_null(out->next->next);
 
-	free_string_list(out);
+	free_name_list(out);
 	free_policy_node(node);
 }
 END_TEST

--- a/tests/functional/end-to-end.bats
+++ b/tests/functional/end-to-end.bats
@@ -21,7 +21,7 @@ do_test() {
 	local FILENAME=$2
 	local EXPECT=$3
 	local ARGS=$4
-	run ${SELINT_PATH} -s -c tmp.conf ${ARGS} ./policies/check_triggers/${FILENAME} ./policies/check_triggers/modules.conf ./policies/check_triggers/obj_perm_sets.spt ./policies/check_triggers/access_vectors
+	run ${SELINT_PATH} -s -c tmp.conf ${ARGS} ./policies/check_triggers/${FILENAME} ./policies/check_triggers/modules.conf ./policies/check_triggers/obj_perm_sets.spt ./policies/check_triggers/access_vectors ./policies/check_triggers/security_classes
 	echo $output
 	[ "$status" -eq 0 ]
 	count=$(echo ${output} | grep -o ${CHECK_ID} | wc -l)
@@ -220,21 +220,25 @@ test_report_format_impl() {
 }
 
 @test "W-001" {
-	test_one_check_expect "W-001" "w01*" 5
+	test_one_check_expect "W-001" "w01*" 6
 }
 
 @test "W-002" {
 	test_one_check_expect "W-002" "w02.*" 2
 	test_one_check "W-002" "w02_role.*"
 	test_one_check_expect "W-002" "w02.bad_if.if" 0
+	test_one_check_expect "W-002" "w02_system_nowarn.if" 0
+	test_one_check_expect "W-002" "w02_system_warn.if" 1
 }
 
 @test "W-003" {
 	test_one_check "W-003" "w03.if"
-	test_one_check "W-003" "w03_role.if"
+	test_one_check_expect "W-003" "w03_role.if" 4
 	test_one_check_expect "W-003" "w03_ta.if" 0
 	test_one_check_expect "W-003" "w03_alias.if" 0
 	test_one_check_expect "W-003" "w03_stub.if" 0
+	test_one_check_expect "W-003" "w03_system_nowarn.if" 0
+	test_one_check_expect "W-003" "w03_system_warn.if" 1
 }
 
 @test "W-004" {

--- a/tests/functional/policies/check_triggers/access_vectors
+++ b/tests/functional/policies/check_triggers/access_vectors
@@ -1,3 +1,7 @@
 class file { read open }
 
 class dir { read open search }
+
+class system { ipc_info halt }
+
+class dbus { send_msg }

--- a/tests/functional/policies/check_triggers/security_classes
+++ b/tests/functional/policies/check_triggers/security_classes
@@ -1,0 +1,5 @@
+class file
+class dir
+class ipc
+class system
+class dbus # userspace

--- a/tests/functional/policies/check_triggers/w01.te
+++ b/tests/functional/policies/check_triggers/w01.te
@@ -12,3 +12,6 @@ role foo_roles types bar_t;
 typeattribute bar_t foo_domain;
 
 roleattribute bar_r foo_roles;
+
+allow bar_t bar_t:dbus send_msg;
+allow bar_t bar_t:system ipc_info;

--- a/tests/functional/policies/check_triggers/w02_system_nowarn.if
+++ b/tests/functional/policies/check_triggers/w02_system_nowarn.if
@@ -1,0 +1,4 @@
+#comment
+interface(`foo_ipc_info',`
+	allow $1 $1:system ipc_info;
+')

--- a/tests/functional/policies/check_triggers/w02_system_warn.if
+++ b/tests/functional/policies/check_triggers/w02_system_warn.if
@@ -1,0 +1,4 @@
+#comment
+interface(`foo_systemd_halt',`
+	allow $1 $1:system halt;
+')

--- a/tests/functional/policies/check_triggers/w03_role.if
+++ b/tests/functional/policies/check_triggers/w03_role.if
@@ -33,3 +33,33 @@ interface(`this_one_fails',`
 
 	allow $1 foo_t:file read;
 ')
+
+# Comment
+interface(`this_one_fails2',`
+	gen_require(`
+		type foo_t;
+		class file { read };
+	')
+
+	allow $1 foo_t:file read;
+')
+
+# Comment
+interface(`this_one_fails3',`
+	gen_require(`
+		type foo_t;
+		class dir { read };
+	')
+
+	allow $1 foo_t:file read;
+')
+
+# Comment
+interface(`this_one_fails4',`
+	gen_require(`
+		type foo_t;
+		class dbus { send_msg };
+	')
+
+	allow $1 foo_t:file read;
+')

--- a/tests/functional/policies/check_triggers/w03_system_nowarn.if
+++ b/tests/functional/policies/check_triggers/w03_system_nowarn.if
@@ -1,0 +1,7 @@
+#comment
+interface(`foo_halt_systemd',`
+	gen_require(`
+		class system { halt };
+	')
+	allow $1 $1:system halt;
+')

--- a/tests/functional/policies/check_triggers/w03_system_warn.if
+++ b/tests/functional/policies/check_triggers/w03_system_warn.if
@@ -1,0 +1,7 @@
+#comment
+interface(`foo_ipc_info',`
+	gen_require(`
+		class system { ipc_info };
+	')
+	allow $1 $1:system ipc_info;
+')


### PR DESCRIPTION
Expand the check `W-001`, `W-002` and `W-003` to security classes.

Since the `system` class is used both by the kernel and in userspace by systemd some machinery needs to be added to gather the associated used permission.
This can also be reused to infer the type of identifiers, see #206.