### PR TITLE
Support disable commands for tunable conditions

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -846,10 +846,10 @@ cond_expr:
 	;
 
 boolean_block:
-	boolean_open condition CLOSE_PAREN OPEN_CURLY lines CLOSE_CURLY { end_boolean_policy(&cur); }
+	boolean_open condition CLOSE_PAREN maybe_selint_disable OPEN_CURLY lines CLOSE_CURLY { end_boolean_policy(&cur); save_command(cur, $4); free($4); }
 	|
-	boolean_open condition CLOSE_PAREN OPEN_CURLY lines CLOSE_CURLY
-	ELSE OPEN_CURLY lines CLOSE_CURLY { end_boolean_policy(&cur); }
+	boolean_open condition CLOSE_PAREN maybe_selint_disable OPEN_CURLY lines CLOSE_CURLY
+	ELSE OPEN_CURLY lines CLOSE_CURLY { end_boolean_policy(&cur); save_command(cur, $4); free($4); }
 	;
 
 boolean_open:
@@ -858,10 +858,10 @@ boolean_open:
 
 tunable_block:
 	TUNABLE_POLICY OPEN_PAREN BACKTICK { begin_tunable_policy(&cur, @$.first_line); }
-	condition SINGLE_QUOTE COMMA m4_args CLOSE_PAREN { end_tunable_policy(&cur); }
+	condition SINGLE_QUOTE maybe_selint_disable COMMA m4_args CLOSE_PAREN { end_tunable_policy(&cur); save_command(cur, $7); free($7); }
 	|
 	TUNABLE_POLICY OPEN_PAREN { begin_tunable_policy(&cur, @$.first_line); }
-	condition COMMA m4_args CLOSE_PAREN { end_tunable_policy(&cur); }
+	condition maybe_selint_disable COMMA m4_args CLOSE_PAREN { end_tunable_policy(&cur); save_command(cur, $5); free($5); }
 	;
 
 genfscon:

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -102,6 +102,7 @@ SAMPLE_POLICY_FILES=sample_policy_files/access_vectors \
 			sample_policy_files/bool_declarations.te \
 			sample_policy_files/declaring_template.if \
 			sample_policy_files/declaring_template.te \
+			sample_policy_files/disable_booltunable.te \
 			sample_policy_files/disable_comment.if \
 			sample_policy_files/disable_comment.te \
 			sample_policy_files/disable_require.if \

--- a/tests/check_parsing.c
+++ b/tests/check_parsing.c
@@ -29,6 +29,7 @@
 #define EMPTY_TE_FILENAME POLICIES_DIR "empty.te"
 #define SYNTAX_ERROR_FILENAME POLICIES_DIR "syntax_error.te"
 #define BAD_RA_FILENAME POLICIES_DIR "bad_role_allow.te"
+#define DISABLE_BOOLTUNABLE_TE_FILENAME POLICIES_DIR "disable_booltunable.te"
 #define DISABLE_COMMENT_TE_FILENAME POLICIES_DIR "disable_comment.te"
 #define DISABLE_COMMENT_IF_FILENAME POLICIES_DIR "disable_comment.if"
 #define DISABLE_REQUIRE_IF_FILENAME POLICIES_DIR "disable_require.if"
@@ -354,6 +355,51 @@ START_TEST (test_parse_bad_role_allow) {
 	ck_assert_ptr_nonnull(f);
 	ck_assert_ptr_null(yyparse_wrapper(f, BAD_RA_FILENAME, NODE_TE_FILE));
 
+	cleanup_parsing();
+	fclose(f);
+
+}
+END_TEST
+
+START_TEST (test_disable_booltunable_te) {
+
+	set_current_module_name("disable_booltunable");
+
+	FILE *f = fopen(DISABLE_BOOLTUNABLE_TE_FILENAME, "r");
+	ck_assert_ptr_nonnull(f);
+	struct policy_node *ast = yyparse_wrapper(f, DISABLE_BOOLTUNABLE_TE_FILENAME, NODE_TE_FILE);
+	ck_assert_ptr_nonnull(ast);
+
+	const struct policy_node *cur = ast;
+
+	ck_assert_ptr_nonnull(cur);
+	ck_assert_int_eq(NODE_TE_FILE, cur->flavor);
+	ck_assert_ptr_nonnull(cur->next);
+
+	cur = cur->next;
+	ck_assert_int_eq(NODE_HEADER, cur->flavor);
+	ck_assert_ptr_nonnull(cur->next);
+
+	cur = cur->next;
+	ck_assert_int_eq(NODE_DECL, cur->flavor);
+	ck_assert_ptr_nonnull(cur->next);
+
+	cur = cur->next;
+	ck_assert_int_eq(NODE_TUNABLE_POLICY, cur->flavor);
+	ck_assert_str_eq("C-008", cur->exceptions);
+	ck_assert_ptr_nonnull(cur->next);
+
+	cur = cur->next;
+	ck_assert_int_eq(NODE_TUNABLE_POLICY, cur->flavor);
+	ck_assert_str_eq("C-008", cur->exceptions);
+	ck_assert_ptr_nonnull(cur->next);
+
+	cur = cur->next;
+	ck_assert_int_eq(NODE_BOOLEAN_POLICY, cur->flavor);
+	ck_assert_str_eq("C-008", cur->exceptions);
+	ck_assert_ptr_null(cur->next);
+
+	free_policy_node(ast);
 	cleanup_parsing();
 	fclose(f);
 
@@ -1066,6 +1112,7 @@ static Suite *parsing_suite(void) {
 	tcase_add_test(tc_core, test_parse_empty_file);
 	tcase_add_test(tc_core, test_syntax_error);
 	tcase_add_test(tc_core, test_parse_bad_role_allow);
+	tcase_add_test(tc_core, test_disable_booltunable_te);
 	tcase_add_test(tc_core, test_disable_comment_te);
 	tcase_add_test(tc_core, test_disable_comment_if);
 	tcase_add_test(tc_core, test_disable_require_if);

--- a/tests/sample_policy_files/disable_booltunable.te
+++ b/tests/sample_policy_files/disable_booltunable.te
@@ -1,0 +1,18 @@
+policy_module(booltunable, 1.0)
+
+type foo_t;
+
+tunable_policy(tunable1 #selint-disable:C-008
+,`
+	allow foo_t foo_t:cls perm;
+')
+
+tunable_policy(`tunable2 && tunable3' #selint-disable:C-008
+,`
+	allow foo_t foo_t:cls perm;
+')
+
+if (bool1) #selint-disable:C-008
+{
+	allow foo_t foo_t:cls perm;
+}


### PR DESCRIPTION
Especially useful to disable C-008.

Syntax:

    tunable_policy(tunable1 #selint-disable:C-008
    ,`
	    ...
    ')

    if (bool1) #selint-disable:C-008
    {
	    ...
    }