### PR TITLE
ci: force usage of DWARF4 by clang

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
       run : |
         cd check/
         autoreconf --install
-        ./configure --prefix=/usr
+        ./configure --prefix=/usr || (cat config.log; exit 1;)
         make
         sudo make install
         sudo ldconfig
@@ -69,9 +69,9 @@ jobs:
       run: |
         if [[ ${{ matrix.cc }} == 'gcc' ]]
         then
-          ./configure --enable-werror CFLAGS=--coverage
+          ./configure --enable-werror CFLAGS=--coverage || (cat config.log; exit 1;)
         else
-          ./configure --enable-werror
+          ./configure --enable-werror || (cat config.log; exit 1;)
         fi
     - name: make
       run: make

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,15 +28,19 @@ jobs:
       CC: ${{ matrix.cc }}
     steps:
     - uses: actions/checkout@v3
+    # Prevent Clang from using DWARF5, not supported by the valgrind version in runners
+    - name: Set environment for Clang
+      run: |
+        echo "CC=clang-15" >> $GITHUB_ENV
+        echo "CFLAGS=-gdwarf-4 -O2" >> $GITHUB_ENV
+      if: ${{ matrix.cc == 'clang' }}
     - name: install clang repo
       run: |
-        if [[ ${{ matrix.cc }} == 'clang' ]]
-        then
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key 2>/dev/null | sudo apt-key add -
-          sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main' -y
-          sudo apt-get update -q
-          sudo apt-get install -y clang-15
-        fi
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key 2>/dev/null | sudo apt-key add -
+        sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main' -y
+        sudo apt-get update -q
+        sudo apt-get install -y clang-15
+      if: ${{ matrix.cc == 'clang' }}
     - name: install dependencies
       run: |
         sudo apt-get update -q
@@ -67,7 +71,7 @@ jobs:
         then
           ./configure --enable-werror CFLAGS=--coverage
         else
-          ./configure --enable-werror CC=clang-15
+          ./configure --enable-werror
         fi
     - name: make
       run: make

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,9 +72,9 @@ jobs:
     - name: make
       run: make
     - name: make check
-      run: make check
+      run: make check || (cat tests/test-suite.log; exit 1;)
     - name: make check-valgrind
-      run: make check-valgrind
+      run: make check-valgrind || (cat tests/test-suite-memcheck.log; exit 1;)
     - name: make distcheck
       run: make distcheck DISTCHECK_CONFIGURE_FLAGS=--enable-werror
     - name: functional tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       CC: ${{ matrix.cc }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: install clang repo
       run: |
         if [[ ${{ matrix.cc }} == 'clang' ]]
@@ -44,7 +44,7 @@ jobs:
     # Install libcheck from source.  Ubuntu is on version 0.10.0, and ck_assert_ptr_null and
     # ck_assert_ptr_nonnull were added in 0.11.0
     - name: checkout check
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: libcheck/check
         ref: 0.15.2
@@ -91,7 +91,7 @@ jobs:
         cd tests/functional
         BATS_TIME_EXPENSIVE=1 bats end-to-end.bats
     - name: checkout refpolicy
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: SELinuxProject/refpolicy
         path: refpolicy
@@ -141,6 +141,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: check-whitespaces
         run: git diff-tree --check $(git hash-object -t tree /dev/null) HEAD


### PR DESCRIPTION
The version of valgrind in the Ubuntu runners does not fully support DWARF5 yet.

Also bump the actions/checkout version to v3.