### PR TITLE
tests: really skip valgrind tests if valgrind is not available

### DIFF
--- a/tests/functional/end-to-end.bats
+++ b/tests/functional/end-to-end.bats
@@ -371,7 +371,11 @@ test_report_format_impl() {
 }
 
 @test "valgrind" {
-	test -z $CI && (command -v valgrind >/dev/null 2>&1 || skip "valgrind not found")
+	run command -v valgrind 2>&1
+	if [ "$status" -ne 0 ] && test -z "$CI"; then
+		skip "valgrind not found"
+	fi
+
 	run valgrind --leak-check=full --show-leak-kinds=all --errors-for-leak-kinds=all --error-exitcode=1 ${SELINT_PATH} -c configs/default.conf -r -s policies/check_triggers
 	[ "$status" -eq 0 ]
 }
@@ -424,7 +428,11 @@ test_report_format_impl() {
 }
 
 @test "Broken config" {
-	test -z $CI && (command -v valgrind >/dev/null 2>&1 || skip "valgrind not found")
+	run command -v valgrind 2>&1
+	if [ "$status" -ne 0 ] && test -z "$CI"; then
+		skip "valgrind not found"
+	fi
+
 	run valgrind --leak-check=full --show-leak-kinds=all --errors-for-leak-kinds=all --error-exitcode=1 ${SELINT_PATH} -c configs/broken.conf -rs policies/check_triggers
 	[ "$status" -eq 78 ]
 }


### PR DESCRIPTION
I tried to be too clever with the one-liner, since running `command` does not work as expected when executed by bats (only directly in a shell).