### PR TITLE
Support genfscon partial paths to be a quoted string

### DIFF
--- a/src/lex.l
+++ b/src/lex.l
@@ -157,7 +157,7 @@ userdebug_or_eng { return USERDEBUG_OR_ENG; }
 [0-9a-zA-Z\$\/][a-zA-Z0-9_\$\*\/\-]* { yylval->string = xstrdup(yytext); return NUM_STRING; }
 [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} { yylval->string = xstrdup(yytext); return IPV4; }
 ([0-9A-Fa-f]{1,4})?\:([0-9A-Fa-f\:])*\:([0-9A-Fa-f]{1,4})?(\:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})? { yylval->string = xstrdup(yytext); return IPV6; }
-\"[a-zA-Z0-9_\.\-\:~\$\[\]]*\" { yylval->string = xstrdup(yytext); return QUOTED_STRING; }
+\"[a-zA-Z0-9_\.\-\:~\$\[\]\/]*\" { yylval->string = xstrdup(yytext); return QUOTED_STRING; }
 \-[\-ldbcsp][ \t] { return FILE_TYPE_SPECIFIER; }
 \( { return OPEN_PAREN; }
 \) { return CLOSE_PAREN; }

--- a/src/parse.y
+++ b/src/parse.y
@@ -178,6 +178,7 @@
 %type<sl> xperm_items
 %type<sl> spt_contents
 %type<sl> spt_content
+%type<string> string_or_quoted_string
 %type<string> sl_item
 %type<string> xperm_item
 %type<sl> arg_list
@@ -484,16 +485,20 @@ strings:
 	sl_item { $$ = sl_from_str_consume($1); }
 	;
 
-sl_item:
+string_or_quoted_string:
 	STRING
+	|
+	QUOTED_STRING
+	;
+
+sl_item:
+	string_or_quoted_string
 	|
 	DASH STRING { $$ = xmalloc(sizeof(char) * (strlen($2) + 2));
 			$$[0] = '-';
 			$$[1] = '\0';
 			strcat($$, $2);
 			free($2);}
-	|
-	QUOTED_STRING
 	;
 
 comma_string_list:
@@ -869,9 +874,9 @@ tunable_block:
 	;
 
 genfscon:
-	GENFSCON STRING STRING genfscon_context { free($2); free($3); }
+	GENFSCON STRING string_or_quoted_string genfscon_context { free($2); free($3); }
 	|
-	GENFSCON NUM_STRING STRING genfscon_context { free($2); free($3); }
+	GENFSCON NUM_STRING string_or_quoted_string genfscon_context { free($2); free($3); }
 	;
 
 genfscon_context:

--- a/tests/sample_policy_files/uncommon.te
+++ b/tests/sample_policy_files/uncommon.te
@@ -20,6 +20,7 @@ portcon udp 7007 gen_context(system_u:object_r:afs_bos_port_t,s0,s1:c0.c225)
 portcon udp 7007-7008 gen_context(system_u:object_r:afs_bos_port_t,s0)
 fs_use_trans devtmpfs gen_context(system_u:object_r:device_t,s0);
 genfscon sysfs /devices/system/cpu/online gen_context(system_u:object_r:cpu_online_t,s0)
+genfscon cgroup "/system.slice" -d gen_context(system_u:object_r:cgroup_system_slice_t,s0)
 fs_use_xattr btrfs gen_context(system_u:object_r:fs_t,s0);
 fs_use_task eventpollfs gen_context(system_u:object_r:fs_t,s0);
 


### PR DESCRIPTION
Required if the path contains a dot.