### PR TITLE
Update GitHub action for releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,10 @@ jobs:
       fail-fast: false
       matrix:
         cc: [ 'gcc', 'clang' ]
+        include:
+          - is_release_job: false
+          - is_release_job: true
+            cc: 'gcc'
     env:
       CC: ${{ matrix.cc }}
     steps:
@@ -107,12 +111,12 @@ jobs:
     - name: Release Info
       id: release_info
       run: |
-        if [[ '${{ github.ref }}' == refs/tags/v* && ${{ matrix.cc }} == 'gcc' ]]
+        if [[ '${{ github.ref }}' == refs/tags/v* && ${{ matrix.is_release_job }} == 'true' ]]
         then
-          echo ::set-output name=is_release::true
-          echo ::set-output name=tag::$(echo ${{ github.ref }} | cut -dv -f2)
+          echo is_release=true >> $GITHUB_OUTPUT
+          echo tag=$(echo ${{ github.ref }} | cut -dv -f2) >> $GITHUB_OUTPUT
         else
-          echo ::set-output name=is_release::false
+          echo is_release=false >> $GITHUB_OUTPUT
         fi
       shell: bash
 


### PR DESCRIPTION
Currently, the matrix configuration definitions and logic in the 'Release Info' step for which one of those configurations to use is far apart in the main.yml file. If the matrix configuration ever changes it can be difficult to also remember to update the 'Release Info' step, which can lead to failed releases.

To make this error less like, this adds a new 'is_release_job' matrix include that is set to false by default, but set to true for the one matrix configuration that should be used for building releases. Since these are near each other and all configured in the 'matrix' setting, it should hopefully be easier to remember to make updates if needed. Now matrix updates no longer require changes to the 'Release Info' step.

This also modifies the 'Release Info' step to remove the deprecated set-output command:

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/