### PR TITLE
Add check for fcontext lines containing only spaces

### DIFF
--- a/README
+++ b/README
@@ -174,6 +174,7 @@ CHECK IDS
 	S-008: Unquoted gen_require block
 	S-009: Permission macro suffix does not match class name
 	S-010: Permission macro usage suggested
+	S-011: File context line containing only white spaces
 
 	W-001: Type, attribute or userspace class referenced without explicit declaration
 	W-002: Type, attribute, role or userspace class used but not listed in require block in interface

--- a/check_examples.txt
+++ b/check_examples.txt
@@ -87,6 +87,10 @@ S-010:
 
 	allow foo_t bar_t:file { open read };
 
+S-011:
+
+	# file context line containing only white spaces
+
 Warning:
 
 W-001:

--- a/src/check_hooks.h
+++ b/src/check_hooks.h
@@ -48,6 +48,7 @@ enum style_ids {
 	S_ID_UNQUOTE_GENREQ = 8,
 	S_ID_PERM_SUFFIX    = 9,
 	S_ID_PERMMACRO      = 10,
+	S_ID_FC_SPACES      = 11,
 	S_END
 };
 

--- a/src/fc_checks.c
+++ b/src/fc_checks.c
@@ -170,11 +170,15 @@ struct check_result *check_file_context_error_nodes(__attribute__((unused)) cons
                                                     *node)
 {
 
-	if (node->flavor != NODE_ERROR) {
-		return NULL;
+	if (node->flavor == NODE_ERROR) {
+		return make_check_result('E', E_ID_FC_ERROR, "Bad file context format");
 	}
 
-	return make_check_result('E', E_ID_FC_ERROR, "Bad file context format");
+	if (node->flavor == NODE_EMPTY) {
+		return make_check_result('S', S_ID_FC_SPACES, "File context line containing only white spaces");
+	}
+
+	return alloc_internal_error("Invalid node type for `check_file_context_error_nodes`");
 }
 
 struct check_result *check_file_context_users(__attribute__((unused)) const struct check_data *data,

--- a/src/runner.c
+++ b/src/runner.c
@@ -208,6 +208,10 @@ struct checks *register_checks(char level,
 			add_check(NODE_AV_RULE, ck, "S-010",
 			          check_perm_macro_available);
 		}
+		if (CHECK_ENABLED("S-011")) {
+			add_check(NODE_EMPTY, ck, "S-011",
+			          check_file_context_error_nodes);
+		}
 		// FALLTHRU
 	case 'W':
 		if (CHECK_ENABLED("W-001")) {

--- a/tests/check_fc_checks.c
+++ b/tests/check_fc_checks.c
@@ -250,7 +250,12 @@ START_TEST (test_check_file_context_error_nodes) {
 
 	struct check_result *res = check_file_context_error_nodes(data, node);
 
-	ck_assert_ptr_null(res);
+	ck_assert_ptr_nonnull(res);
+	ck_assert_int_eq(res->severity, 'F');
+	ck_assert_int_eq(res->check_id, F_ID_INTERNAL);
+	ck_assert_ptr_nonnull(res->message);
+
+	free_check_result(res);
 
 	node->flavor = NODE_ERROR;
 

--- a/tests/check_parse_fc.c
+++ b/tests/check_parse_fc.c
@@ -55,6 +55,23 @@ START_TEST (test_parse_context_missing_field) {
 }
 END_TEST
 
+START_TEST (test_parse_fc_empty) {
+
+	char line[] = "";
+
+	struct fc_entry *out = parse_fc_line(line);
+
+	ck_assert_ptr_null(out);
+
+	char line2[] = " ";
+
+	out = parse_fc_line(line2);
+
+	ck_assert_ptr_null(out);
+
+}
+END_TEST
+
 START_TEST (test_parse_fc_line_with_gen_context) {
 	char line[] = "/usr/bin(/.*)?		gen_context(system_u:object_r:bin_t, s0)";
 
@@ -147,7 +164,17 @@ START_TEST (test_parse_basic_fc_file) {
 
 	cur = cur->next;
 
+	ck_assert_int_eq(cur->flavor, NODE_EMPTY);
+	ck_assert_ptr_nonnull(cur->next);
+
+	cur = cur->next;
+
 	ck_assert_int_eq(cur->flavor, NODE_ERROR);
+	ck_assert_ptr_nonnull(cur->next);
+
+	cur = cur->next;
+
+	ck_assert_int_eq(cur->flavor, NODE_EMPTY);
 	ck_assert_ptr_nonnull(cur->next);
 
 	cur = cur->next;
@@ -202,9 +229,18 @@ START_TEST (test_parse_none_context) {
 	struct policy_node *cur = ast->next;
 
 	ck_assert_int_eq(cur->flavor, NODE_FC_ENTRY);
-	ck_assert_ptr_null(cur->next);
+	ck_assert_ptr_nonnull(cur->next);
 
 	struct fc_entry *data = cur->data.fc_data;
+
+	ck_assert_ptr_null(data->context);
+
+	cur = cur->next;
+
+	ck_assert_int_eq(cur->flavor, NODE_FC_ENTRY);
+	ck_assert_ptr_null(cur->next);
+
+	data = cur->data.fc_data;
 
 	ck_assert_ptr_null(data->context);
 
@@ -236,6 +272,7 @@ static Suite *parse_fc_suite(void) {
 
 	tcase_add_test(tc_core, test_parse_context);
 	tcase_add_test(tc_core, test_parse_context_missing_field);
+	tcase_add_test(tc_core, test_parse_fc_empty);
 	tcase_add_test(tc_core, test_parse_fc_line_with_gen_context);
 	tcase_add_test(tc_core, test_parse_fc_line);
 	tcase_add_test(tc_core, test_parse_fc_line_with_obj);

--- a/tests/sample_policy_files/basic.fc
+++ b/tests/sample_policy_files/basic.fc
@@ -1,8 +1,8 @@
 /usr/bin/basic			--		gen_context(system_u:object_r:basic_t, s0)
 /etc/basic(/.*)?				gen_context(system_u:object_r:basic_conf_t, s0)
-
+ 
 /var/www/basic					gen_this_is_an_error(system_u:obect_r:basic_conf_t, s0)
-
+	
 /var/log/basic.log		--		system_u:object_r:basic_log_t:s0
 
 /var/www/basic/basic.conf	--		gen_context(system_u:object_r:basic_conf_t, s0, c1)

--- a/tests/sample_policy_files/none_context.fc
+++ b/tests/sample_policy_files/none_context.fc
@@ -1,1 +1,2 @@
 /path/path			<<none>>
+/path/path2			<<none>>  


### PR DESCRIPTION
Currently file context definition lines containing only white spaces will result in an error:

    libraries.mod.fc:   130: (E): Bad file context format (E-002)

Support parsing those lines and issue a new style check.

Suggested in https://github.com/SELinuxProject/refpolicy/pull/763.