### PR TITLE
Support CIDR address notation in nodecon statement

### DIFF
--- a/src/lex.l
+++ b/src/lex.l
@@ -156,7 +156,9 @@ userdebug_or_eng { return USERDEBUG_OR_ENG; }
 [a-zA-Z\$\/][a-zA-Z0-9_\$\*\/\-]* { yylval->string = xstrdup(yytext); return STRING; }
 [0-9a-zA-Z\$\/][a-zA-Z0-9_\$\*\/\-]* { yylval->string = xstrdup(yytext); return NUM_STRING; }
 [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} { yylval->string = xstrdup(yytext); return IPV4; }
+[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\/[0-9]{1,2} { yylval->string = xstrdup(yytext); return IPV4_CIDR; }
 ([0-9A-Fa-f]{1,4})?\:([0-9A-Fa-f\:])*\:([0-9A-Fa-f]{1,4})?(\:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})? { yylval->string = xstrdup(yytext); return IPV6; }
+([0-9A-Fa-f]{1,4})?\:([0-9A-Fa-f\:])*\:([0-9A-Fa-f]{1,4})?(\:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})?\/[0-9]{1,3} { yylval->string = xstrdup(yytext); return IPV6_CIDR; }
 \"[a-zA-Z0-9_\.\-\:~\$\[\]\/]*\" { yylval->string = xstrdup(yytext); return QUOTED_STRING; }
 \-[\-ldbcsp][ \t] { return FILE_TYPE_SPECIFIER; }
 \( { return OPEN_PAREN; }

--- a/src/parse.y
+++ b/src/parse.y
@@ -86,7 +86,9 @@
 %token <string> STRING;
 %token <string> NUM_STRING;
 %token <string> IPV4;
+%token <string> IPV4_CIDR;
 %token <string> IPV6;
+%token <string> IPV6_CIDR;
 %token <string> NUMBER;
 %token <string> QUOTED_STRING;
 %token <string> VERSION_NO;
@@ -909,12 +911,20 @@ netifcon:
 
 nodecon:
 	NODECON two_ip_addrs context
+	|
+	NODECON cidr_addr context
 	;
 
 two_ip_addrs:
 	IPV4 IPV4 { free($1); free($2); }
 	|
 	IPV6 IPV6 { free($1); free($2); }
+	;
+
+cidr_addr:
+	IPV4_CIDR { free($1); }
+	|
+	IPV6_CIDR { free($1); }
 	;
 
 fs_use:

--- a/tests/sample_policy_files/uncommon.te
+++ b/tests/sample_policy_files/uncommon.te
@@ -46,8 +46,10 @@ optional_policy(`
 netifcon lo gen_context(system_u:object_r:lo_netif_t,s0 - mls_systemhigh) gen_context(system_u:object_r:unlabeled_t,s0 - mls_systemhigh)
 
 nodecon 127.0.0.1 255.255.255.255 gen_context(system_u:object_r:system_t:s0)
+nodecon 127.0.0.0/24 gen_context(system_u:object_r:system_t:s0)
 nodecon ::5 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff gen_context(system_u:object_r:system_t:s0)
 nodecon ::ffff:127.0.0.1 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff gen_context(system_u:object_r:lo_node_t,s0)
+nodecon ::1/128 gen_context(system_u:object_r:lo_node_t,s0)
 
 if (!bool_one) {
 	allow foo_t bar_t:file open;


### PR DESCRIPTION
Supported since checkpolicy 3.7.

https://github.com/SELinuxProject/selinux/commit/804e52b7f8a3c8649615211a961ef8189fe73f39