### PR TITLE
Allow M4 escaped strings inside QUOTED_STRING

### DIFF
--- a/src/lex.l
+++ b/src/lex.l
@@ -159,7 +159,7 @@ userdebug_or_eng { return USERDEBUG_OR_ENG; }
 [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\/[0-9]{1,2} { yylval->string = xstrdup(yytext); return IPV4_CIDR; }
 ([0-9A-Fa-f]{1,4})?\:([0-9A-Fa-f\:])*\:([0-9A-Fa-f]{1,4})?(\:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})? { yylval->string = xstrdup(yytext); return IPV6; }
 ([0-9A-Fa-f]{1,4})?\:([0-9A-Fa-f\:])*\:([0-9A-Fa-f]{1,4})?(\:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})?\/[0-9]{1,3} { yylval->string = xstrdup(yytext); return IPV6_CIDR; }
-\"[a-zA-Z0-9_\.\-\:~\$\[\]\/]*\" { yylval->string = xstrdup(yytext); return QUOTED_STRING; }
+\"\`*[a-zA-Z0-9_\.\-\:~\$\[\]\/]*\'*\" { yylval->string = xstrdup(yytext); return QUOTED_STRING; }
 \-[\-ldbcsp][ \t] { return FILE_TYPE_SPECIFIER; }
 \( { return OPEN_PAREN; }
 \) { return CLOSE_PAREN; }


### PR DESCRIPTION
When a file name in type transition rule used in an interface is same as a keyword, it needs to be M4 escaped so that the keyword is not expanded by M4, e.g.

-	filetrans_pattern($1, virt_var_run_t, virtinterfaced_var_run_t, dir, "interface")
+	filetrans_pattern($1, virt_var_run_t, virtinterfaced_var_run_t, dir, "``interface''")

Fixes:

    $ selint ./policy/modules/contrib/virt.if
    Note: Check E-007 is not performed because no permission macro has been parsed.
    ./policy/modules/contrib/virt.if:169: (F): syntax error, unexpected UNKNOWN_TOKEN (F-001)
      169 |     filetrans_pattern($1, virt_var_run_t, virtinterfaced_var_run_t, dir, "``interface''")
          |                                                                          ^
    ./policy/modules/contrib/virt.if:169: (F): Error: Invalid statement (F-001)
      169 |     filetrans_pattern($1, virt_var_run_t, virtinterfaced_var_run_t, dir, "``interface''")
          |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    Error: Failed to parse files