### PR TITLE
Support m4 quoted strings in interface call arguments

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -188,6 +188,7 @@
 %type<string> arg_list_item
 %type<sl> arg
 %type<sl> args
+%type<sl> arg_m4_quoted
 %type<string> mls_range
 %type<string> mls_level
 %type<string> mls_component
@@ -801,14 +802,22 @@ arg_list_item:
 	NUMBER
 	;
 
+arg_m4_quoted:
+	QUOTED_STRING { $$ = sl_from_str_consume($1); }
+	|
+	mls_range { $$ = sl_from_str_consume($1); }
+	|
+	%empty { $$ = sl_from_str(""); }
+	|
+	BACKTICK arg_m4_quoted SINGLE_QUOTE { $$ = $2; }
+	;
+
 arg:
 	arg_list
 	|
 	QUOTED_STRING { $$ = sl_from_str_consume($1); }
 	|
-	BACKTICK mls_range SINGLE_QUOTE { $$ = sl_from_str_consume($2); }
-	|
-	BACKTICK SINGLE_QUOTE { $$ = sl_from_str(""); }
+	BACKTICK arg_m4_quoted SINGLE_QUOTE { $$ = $2; }
 	;
 
 args:

--- a/tests/sample_policy_files/uncommon.te
+++ b/tests/sample_policy_files/uncommon.te
@@ -158,3 +158,5 @@ optional_policy(`
 	call_some_interface(foo_t)
 ')
 ')
+
+filetrans_pattern(foo_t, bar_run_t, baz_run_t, dir, ``"interface"'')


### PR DESCRIPTION
Required for escaped strings, that would otherwise be replaced by m4, e.g. "interface":

    filetrans_pattern(foo_t, bar_run_t, baz_run_t, dir, ``"interface"'')

Replaces: #289

Note: in contrast to #289 here the syntax is
```
``"interface"''
```
instead of
```
"``interface''"
```