### PR TITLE
Add parse check for new netlink xperm support

### DIFF
--- a/tests/sample_policy_files/uncommon.te
+++ b/tests/sample_policy_files/uncommon.te
@@ -160,3 +160,5 @@ optional_policy(`
 ')
 
 filetrans_pattern(foo_t, bar_run_t, baz_run_t, dir, ``"interface"'')
+
+allowxperm src_t tgt_t: netlink_route_socket nlmsg { RTM_GETROUTE 0x44 };


### PR DESCRIPTION
Based on documentation here: https://github.com/SELinuxProject/selinux-notebook/pull/40/files

This test already passes out of the box, because our XPERM parse support is pretty generic, but I figure its worth being more explicit in our test files.