### PR TITLE
Call bison with -Wno-other

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,7 +15,7 @@
 bin_PROGRAMS = selint
 selint_SOURCES = main.c lex.l parse.y tree.c tree.h selint_error.h parse_functions.c parse_functions.h maps.c maps.h runner.c runner.h parse_fc.c parse_fc.h template.c template.h file_list.c file_list.h check_hooks.c check_hooks.h fc_checks.c fc_checks.h util.c util.h if_checks.c if_checks.h selint_config.c selint_config.h string_list.c string_list.h startup.c startup.h te_checks.c te_checks.h ordering.c ordering.h color.c color.h perm_macro.c perm_macro.h xalloc.h name_list.c name_list.h
 BUILT_SOURCES = parse.h
-AM_YFLAGS = -d -Wno-yacc -Werror=conflicts-rr -Werror=conflicts-sr
+AM_YFLAGS = -d -Wno-other -Wno-yacc -Werror=conflicts-rr -Werror=conflicts-sr
 
 if COND_GCOV
 MAYBE_COVERAGE=--coverage -fno-inline -fno-inline-small-functions -fno-default-inline


### PR DESCRIPTION
Bison in 3.8.2 added new warnings to catch m4 strings accidentally included in the generated code output.  It had the unfortunate side effect of flagging grammars that include "m4_foo" style strings as identifiers in their grammar (which we do).  Based on the thread, it looks like a fix was implemented on the Bison side, but as of three years later, no release has been made.  Bison seems to possibly have maintainer inactivity: https://github.com/akimd/bison/issues/103.

Since a fix for the false positive is not forthcoming, disable the warning.  Unfortunately, I don't think a more granular disablement is available, but IMO false positive warnings are worse than false negatives.