### PR TITLE
Allow @ in quoted string token

### DIFF
--- a/src/lex.l
+++ b/src/lex.l
@@ -159,7 +159,7 @@ userdebug_or_eng { return USERDEBUG_OR_ENG; }
 [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\/[0-9]{1,2} { yylval->string = xstrdup(yytext); return IPV4_CIDR; }
 ([0-9A-Fa-f]{1,4})?\:([0-9A-Fa-f\:])*\:([0-9A-Fa-f]{1,4})?(\:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})? { yylval->string = xstrdup(yytext); return IPV6; }
 ([0-9A-Fa-f]{1,4})?\:([0-9A-Fa-f\:])*\:([0-9A-Fa-f]{1,4})?(\:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})?\/[0-9]{1,3} { yylval->string = xstrdup(yytext); return IPV6_CIDR; }
-\"[a-zA-Z0-9_\.\-\:~\$\[\]\/]*\" { yylval->string = xstrdup(yytext); return QUOTED_STRING; }
+\"[a-zA-Z0-9_\.\-\:~\$\[\]\/@]*\" { yylval->string = xstrdup(yytext); return QUOTED_STRING; }
 \-[\-ldbcsp][ \t] { return FILE_TYPE_SPECIFIER; }
 \( { return OPEN_PAREN; }
 \) { return CLOSE_PAREN; }


### PR DESCRIPTION
Fixes:

    base-policy/policy/modules/system/systemd.te:1400: (F): syntax error, unexpected UNKNOWN_TOKEN (F-001)
     1400 | filetrans_pattern(systemd_zram_generator_t, systemd_unit_file_t, systemd_zram_generator_unit_file_t, dir, "systemd-zram-setup@zram0.service.d")
          |                                                                                                           ^
    base-policy/policy/modules/system/systemd.te:1400: (F): Error: Invalid statement (F-001)
     1400 | filetrans_pattern(systemd_zram_generator_t, systemd_unit_file_t, systemd_zram_generator_unit_file_t, dir, "systemd-zram-setup@zram0.service.d")
          | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    Error: Failed to parse files