### PR TITLE
[RFC] Add support for gen_system_context

### DIFF
--- a/src/lex.l
+++ b/src/lex.l
@@ -146,6 +146,7 @@ fs_use_task { return FS_USE_TASK; }
 define { return DEFINE; }
 gen_user { return GEN_USER; }
 gen_context { return GEN_CONTEXT; }
+gen_system_context { return GEN_SYSTEM_CONTEXT; }
 permissive { return PERMISSIVE; }
 typebounds { return TYPEBOUNDS; }
 interface { return INTERFACE; }

--- a/src/main.c
+++ b/src/main.c
@@ -654,6 +654,7 @@ int main(int argc, char **argv)
 		free(security_classes_path);
 		free(modules_conf_path);
 		free_string_list(global_cond_files);
+		free_string_list(custom_fc_macros);
 		return EX_CONFIG;
 	}
 
@@ -698,6 +699,7 @@ int main(int argc, char **argv)
 	free_file_list(fc_files);
 	free_file_list(context_te_files);
 	free_file_list(context_if_files);
+	free_string_list(custom_fc_macros);
 	free_selint_config(&ccd);
 
 	if (fail_on_finding && found_issue && exit_code == EX_OK) {

--- a/src/parse.y
+++ b/src/parse.y
@@ -146,6 +146,7 @@
 %token DEFINE;
 %token GEN_USER;
 %token GEN_CONTEXT;
+%token GEN_SYSTEM_CONTEXT;
 %token PERMISSIVE;
 %token TYPEBOUNDS;
 %token INTERFACE;
@@ -993,6 +994,12 @@ context:
 	GEN_CONTEXT OPEN_PAREN raw_context COMMA mls_range COMMA mls_range CLOSE_PAREN { free($5); free($7); }
 	|
 	GEN_CONTEXT OPEN_PAREN raw_context COMMA mls_range COMMA CLOSE_PAREN { free($5); }
+	|
+	GEN_SYSTEM_CONTEXT OPEN_PAREN STRING CLOSE_PAREN { free($3); }
+	|
+	GEN_SYSTEM_CONTEXT OPEN_PAREN STRING COMMA mls_range CLOSE_PAREN { free($3); free($5); }
+	|
+	GEN_SYSTEM_CONTEXT OPEN_PAREN STRING COMMA mls_range COMMA mls_range CLOSE_PAREN { free($3); free($5); free($7); }
 	;
 
 raw_context:

--- a/src/parse_fc.c
+++ b/src/parse_fc.c
@@ -219,12 +219,14 @@ bool check_for_fc_macro(const char *line, const struct string_list *custom_fc_ma
 		if (line_len <= custom_fc_len) {
 			continue;
 		}
-		if (line[custom_fc_len] != '(') {
+		const char *begin = strstr(line, custom_fc_macros->string);
+		if (!begin) {
 			continue;
 		}
-		if (0 == strncmp(line, custom_fc_macros->string, custom_fc_len)) {
-			return true;
+		if (begin[custom_fc_len] != '(') {
+			continue;
 		}
+		return true;
 	}
 	return false;
 }

--- a/tests/functional/end-to-end.bats
+++ b/tests/functional/end-to-end.bats
@@ -487,7 +487,7 @@ test_report_format_impl() {
 	run ${SELINT_PATH} -c configs/default.conf -s policies/misc/fc_macros.fc
 	count=$(echo ${output} | grep -o "E-002" | wc -l)
 	echo ${output}
-	[ "$count" -eq 1 ]
+	[ "$count" -eq 2 ]
 	run ${SELINT_PATH} -c configs/fc_macros.conf -s policies/misc/fc_macros.fc
 	count=$(echo ${output} | grep -o "E-002" | wc -l)
 	echo ${output}

--- a/tests/functional/end-to-end.bats
+++ b/tests/functional/end-to-end.bats
@@ -486,6 +486,7 @@ test_report_format_impl() {
 @test "custom_fc_macros" {
 	run ${SELINT_PATH} -c configs/default.conf -s policies/misc/fc_macros.fc
 	count=$(echo ${output} | grep -o "E-002" | wc -l)
+	echo ${output}
 	[ "$count" -eq 1 ]
 	run ${SELINT_PATH} -c configs/fc_macros.conf -s policies/misc/fc_macros.fc
 	count=$(echo ${output} | grep -o "E-002" | wc -l)

--- a/tests/functional/policies/misc/fc_macros.fc
+++ b/tests/functional/policies/misc/fc_macros.fc
@@ -1,3 +1,5 @@
 my_custom_macro(`foo')
 
 /foo	--	gen_context(system_u:object_r:foo_t, s0)
+
+/foo/bar	my_custom_macro(foo_t)

--- a/tests/sample_policy_files/uncommon.te
+++ b/tests/sample_policy_files/uncommon.te
@@ -13,6 +13,7 @@ type this_shouldnt_be_allowed_t alias other_name_t, attr_name;
 permissive foo_t;
 
 sid netmsg gen_context(system_u:object_r:netlabel_peer_t,mls_systemhigh)
+sid netmsg gen_system_context(netlabel_peer_t,mls_systemhigh)
 
 portcon udp 7007 gen_context(system_u:object_r:afs_bos_port_t,s0)
 portcon udp 7007 gen_context(system_u:object_r:afs_bos_port_t,s0:c2)


### PR DESCRIPTION
Support a wrapper for `gen_context(system_u:object_r:CTX, s0)` named `gen_system_context(CTX)`.

Support it as alternative to gen_context() in .te via the parser and in .fc files via extending the custom_fc_macros search logic.



I am not sure whether it's worth to have something non-reference style specific like this in SELint though.

Depends on #298.