### PR TITLE
Add system permissions added to Linux for 6.15

### DIFF
--- a/src/maps.c
+++ b/src/maps.c
@@ -317,6 +317,11 @@ int is_userspace_class(const char *class_name, const struct string_list *permiss
 		    0 != strcmp(p->string, "syslog_console") &&
 		    0 != strcmp(p->string, "module_request") &&
 		    0 != strcmp(p->string, "module_load") &&
+		    0 != strcmp(p->string, "firmware_load") &&
+		    0 != strcmp(p->string, "kexec_image_load") &&
+		    0 != strcmp(p->string, "kexec_initramfs_load") &&
+		    0 != strcmp(p->string, "policy_load") &&
+		    0 != strcmp(p->string, "x509_certificate_load") &&
 		    0 != strcmp(p->string, "*") &&
 		    0 != strcmp(p->string, "~")) {
 			return 1;


### PR DESCRIPTION
For deciding whether a permission of the system class is a userspace or kernel one the kernel ones are hardcoded.  Add the ones to be introduced in Linux 6.15 with commit 2c2b1e059792 ("selinux: add permission checks for loading other kinds of kernel files").

See https://github.com/SELinuxProject/selinux-kernel/commit/2c2b1e059792f610bae4fee8ed517b8ce9c585fb